### PR TITLE
✨ Support for out-of-place platforms and tests

### DIFF
--- a/src/framework/scenario/Actions.ts
+++ b/src/framework/scenario/Actions.ts
@@ -36,7 +36,7 @@ export function awaitBreakpoint(): Action<Breakpoint> {
                     try {
                         const breakpoint = breakpointHitParser(message);
                         // on success: remove listener + resolve
-                        testee.testbed?.removeListener(TestbedEvents.OnMessage, breakpointListener);
+                        testee.bed()?.removeListener(TestbedEvents.OnMessage, breakpointListener);
                         resolve(assertable(breakpoint));
                     } catch (e) {
 
@@ -44,7 +44,7 @@ export function awaitBreakpoint(): Action<Breakpoint> {
                 }
 
                 // await breakpoint hit
-                testee.testbed?.on(TestbedEvents.OnMessage, breakpointListener)
+                testee.bed()?.on(TestbedEvents.OnMessage, breakpointListener)
             });
         }
     };

--- a/src/framework/scenario/Invoker.ts
+++ b/src/framework/scenario/Invoker.ts
@@ -1,17 +1,24 @@
 import {Expectation, Expected, Instruction, Kind, Step} from './Step';
 import {WASM} from '../../sourcemap/Wasm';
-import {Exception, Message} from '../../messaging/Message';
+import {Message} from '../../messaging/Message';
+import {Target} from '../Testee';
 import Value = WASM.Value;
 
 export class Invoker implements Step {
     readonly title: string;
     readonly instruction: Instruction;
     readonly expected?: Expectation[];
+    readonly target?: Target;
 
-    constructor(func: string, args: Value[], result: Value) {
-        this.title = `ASSERT: ${func} ${args.map(val => val.value).join(' ')} ${result.value}`;
+    constructor(func: string, args: Value[], result: Value, target?: Target) {
+        let prefix = "";
         this.instruction = invoke(func, args);
         this.expected = returns(result);
+        if (target !== undefined) {
+            this.target = target;
+            prefix = `${target === Target.supervisor ? '[supervisor] ' : '[proxy]      '}`
+        }
+        this.title = `${prefix}CHECK: (${func} ${args.map(val => val.value).join(' ')}) returns ${result.value}`;
     }
 }
 

--- a/src/framework/scenario/Step.ts
+++ b/src/framework/scenario/Step.ts
@@ -1,5 +1,6 @@
 import {Action} from './Actions';
 import {Request} from '../../messaging/Message'
+import {Target} from '../Testee';
 
 export enum Description {
     /** required properties */
@@ -40,6 +41,8 @@ export interface Step {
     readonly title: string;
 
     readonly instruction: Instruction;
+
+    target?: Target;
 
     readonly expected?: Expectation[];
 }

--- a/src/manage/Uploader.ts
+++ b/src/manage/Uploader.ts
@@ -9,7 +9,7 @@ import {SubProcess} from '../bridge/SubProcess';
 import {Connection} from '../bridge/Connection';
 import {Serial} from '../bridge/Serial';
 import {CompileOutput} from './Compiler';
-import {TestbedSpecification, PlatformType, SerialOptions, SubprocessOptions} from '../testbeds/TestbedSpecification';
+import {PlatformType, SerialOptions, SubprocessOptions, TestbedSpecification} from '../testbeds/TestbedSpecification';
 
 enum UploaderEvents {
     compiled = 'compiled',
@@ -38,11 +38,12 @@ export class UploaderFactory {
             case PlatformType.arduino:
                 return new ArduinoUploader(this.arduino, args, specification.options as SerialOptions);
             case PlatformType.emulator:
+            case PlatformType.emu2emu:
                 return new EmulatorUploader(this.emulator, args, specification.options as SubprocessOptions);
             case PlatformType.debug:
                 return new EmulatorConnector(specification.options as SubprocessOptions)
         }
-        throw new Error('Unsupported file type');
+        throw new Error('Unsupported platform type');
     }
 }
 

--- a/src/messaging/Message.ts
+++ b/src/messaging/Message.ts
@@ -1,5 +1,5 @@
 import {WARDuino} from '../debug/WARDuino';
-import {ackParser, breakpointParser, invokeParser, stateParser} from './Parsers';
+import {ackParser, breakpointParser, identityParser, invokeParser, stateParser} from './Parsers';
 import {Breakpoint} from '../debug/Breakpoint';
 import {WASM} from '../sourcemap/Wasm';
 import {write} from 'ieee754';
@@ -210,4 +210,9 @@ export namespace Message {
         type: Interrupt.dumpCallbackmapping,
         parser: stateParser
     }
+
+    export const proxifyRequest: Request<string> =  {
+        type: Interrupt.proxify,
+        parser: identityParser
+    };
 }

--- a/src/testbeds/TestbedFactory.ts
+++ b/src/testbeds/TestbedFactory.ts
@@ -28,6 +28,7 @@ export class TestbedFactory {
             case PlatformType.arduino:
                 return new Arduino(connection as Serial);
             case PlatformType.emulator:
+            case PlatformType.emu2emu:
             case PlatformType.debug:
                 return new Emulator(connection as SubProcess);
             default:

--- a/src/testbeds/TestbedSpecification.ts
+++ b/src/testbeds/TestbedSpecification.ts
@@ -1,6 +1,7 @@
 export enum PlatformType {
     arduino,
     emulator,
+    emu2emu,
     debug
 }
 
@@ -18,10 +19,26 @@ export interface SubprocessOptions extends ConnectionOptions {
     port: number
 }
 
+export interface SupervisorOptions extends ConnectionOptions {
+    port: number,
+    proxy: number
+}
 
 export interface TestbedSpecification {
     readonly type: PlatformType;
     readonly options: ConnectionOptions;
+}
+
+export class OutofPlaceSpecification implements TestbedSpecification {
+    public readonly type: PlatformType = PlatformType.emu2emu;
+    public readonly options: SupervisorOptions;
+
+    public readonly proxy: EmulatorSpecification;
+
+    constructor(supervisor: number, proxy: number) {
+        this.options = {port: supervisor, proxy: proxy};
+        this.proxy = new EmulatorSpecification(proxy);
+    }
 }
 
 export class EmulatorSpecification implements TestbedSpecification {

--- a/test/dummy.wast
+++ b/test/dummy.wast
@@ -1,0 +1,28 @@
+
+(module
+  ;; Type declarations
+  (type $int32->int32->int32 (func (param i32 i32) (result i32)))
+  (type $int32->int32 (func (param i32) (result i32)))
+  (type $int32->void (func (param i32)))
+  (type $void->void (func))
+
+  ;; Imports from the WARDuino VM
+  (import "env" "dummy" (func $env.dummy (type $int32->int32->int32)))
+  (import "env" "print_int" (func $env.print_int (type $int32->void)))
+
+  ;; Memory
+  (memory 1)
+
+  ;; Main function
+  (func $main (export "main") (type $void->void)
+    (call $env.dummy (i32.const 32) (i32.const 64))
+    (drop)
+    (call $env.print_int (i32.load (i32.const 32)))
+  )
+
+  (func $dummy (export "dummy") (type $int32->int32->int32)
+        (call $env.dummy (local.get 0) (local.get 1)))
+
+  (func $load (export "load") (type $int32->int32)
+        (i32.load (local.get 0)))
+)


### PR DESCRIPTION
**example**

```ts
oop.testee('supervisor[:8100] - proxy[:8150]', new OutofPlaceSpecification(8100, 8150));

oop.test({
    title: `Test store primitive`,
    program: 'test/dummy.wast',
    dependencies: [],
    steps: [{
            title: '[proxy]      CHECK: execution at start of main',
            instruction: {kind: Kind.Request, value: dump},
            expected: [{'pc': {kind: 'primitive', value: 129} as Expected<number>}],
            target: Target.proxy}
]});
```

**new features**

- emulator to emulator out-of-place platform
- `target` field in steps