### PR TITLE
Hotfix for "Error: undefined" in test output

### DIFF
--- a/src/framework/Reporter.ts
+++ b/src/framework/Reporter.ts
@@ -80,7 +80,16 @@ export class ScenarioResult {
     public test: TestScenario;
     public testee: Testee;
     public results: Result[] = [];
-    public error?: Error;
+    // public error?: Error;
+
+    private _error?: Error;
+    public get error(): Error|undefined { return this._error; }
+    public set error(value: Error|undefined) {
+        console.log(`Set error to ${value} (${typeof value})`);
+        if(!value || !value.message)
+        console.log(new Error().stack);
+        this._error = value;
+    }
 
     constructor(test: TestScenario, testee: Testee) {
         this.test = test;

--- a/src/framework/Reporter.ts
+++ b/src/framework/Reporter.ts
@@ -80,16 +80,8 @@ export class ScenarioResult {
     public test: TestScenario;
     public testee: Testee;
     public results: Result[] = [];
-    // public error?: Error;
+    public error?: Error;
 
-    private _error?: Error;
-    public get error(): Error|undefined { return this._error; }
-    public set error(value: Error|undefined) {
-        console.log(`Set error to ${value} (${typeof value})`);
-        if(!value || !value.message)
-        console.log(new Error().stack);
-        this._error = value;
-    }
 
     constructor(test: TestScenario, testee: Testee) {
         this.test = test;

--- a/src/framework/Testee.ts
+++ b/src/framework/Testee.ts
@@ -159,14 +159,16 @@ export class Testee { // TODO unified with testbed interface
             } catch (e) {
                 await testee.initialize(description.program, description.args ?? []).catch((o) => Promise.reject(o));
             }
-        }).catch((e: Error) => {
-            scenarioResult.error = e;
+        }).catch((e: Error|string) => {
+            if(typeof e === 'string') scenarioResult.error = new Error(e);
+            else scenarioResult.error = e;
         });
 
         await this.run('Get source mapping', testee.connector.timeout, async function () {
             map = await testee.mapper.map(description.program);
-        }).catch((e: Error) => {
-            scenarioResult.error = e;
+        }).catch((e: Error|string) => {
+            if(typeof e === 'string') scenarioResult.error = new Error(e);
+            else scenarioResult.error = e;
         });
 
         if (scenarioResult.error) {


### PR DESCRIPTION
Some functions in `src/framework/Testee.ts` catch a `string` as if it were an `Error`:
```ts
        .catch((e: Error) => {
            scenarioResult.error = e;
        });
```

My current fix is to have these catch the error as `Error|string` and then do a type-check to ensure that `scenarioResult.error` is always an `Error|undefined`:
```ts
        .catch((e: Error|string) => {
            if(typeof e === 'string') scenarioResult.error = new Error(e);
            else scenarioResult.error = e;
        });
```