### PR TITLE
💄 Lint

### DIFF
--- a/src/framework/Scheduler.ts
+++ b/src/framework/Scheduler.ts
@@ -87,7 +87,7 @@ function trees(input: TestScenario[]): TestScenario[][][] {
     input.sort(comparator);
 
     // output
-    let forest: TestScenario[][][] = [];
+    const forest: TestScenario[][][] = [];
 
     // scenario that have already been seen
     const seen = new Set<TestScenario>();
@@ -100,7 +100,7 @@ function trees(input: TestScenario[]): TestScenario[][][] {
             continue;
         }
         // start a new tree
-        let t: TestScenario[][] = tree(test);
+        const t: TestScenario[][] = tree(test);
         forest.push(t);
         pointer = forest.length - 1;
 
@@ -129,7 +129,7 @@ function trees(input: TestScenario[]): TestScenario[][][] {
 function tree(root: TestScenario): TestScenario[][] {
     let result: TestScenario[][] = [];
 
-    let lifo: TestScenario[] = [...root.dependencies ?? []];
+    const lifo: TestScenario[] = [...root.dependencies ?? []];
     for (const test of lifo) {
         const c = tree(test);
         result = merge(c, result);
@@ -188,7 +188,7 @@ function levels(input: TestScenario[]): TestScenario[][] {
         const test: TestScenario = input.shift()!;
 
         // skip any test with unresolved dependencies
-        let skip: boolean = (test.dependencies ?? []).some((dependence: TestScenario) => input.includes(dependence));
+        const skip: boolean = (test.dependencies ?? []).some((dependence: TestScenario) => input.includes(dependence));
 
         if (skip) {
             input.push(test);

--- a/src/framework/TestResult.ts
+++ b/src/framework/TestResult.ts
@@ -1,6 +1,5 @@
 import {v4 as randomUUID} from 'uuid';
 
-/* eslint-disable @typescript-eslint/naming-convention */
 export enum Status {
     FAILED = 'failed',
     BROKEN = 'broken',
@@ -8,7 +7,6 @@ export enum Status {
     SKIPPED = 'skipped',
 }
 
-/* eslint-disable @typescript-eslint/naming-convention */
 export enum Stage {
     SCHEDULED = 'scheduled',
     RUNNING = 'running',

--- a/src/framework/Testee.ts
+++ b/src/framework/Testee.ts
@@ -167,7 +167,7 @@ export class Testee { // TODO unified with testbed interface
                 return;
             }
 
-            let compiled: CompileOutput = await new CompilerFactory(WABT).pickCompiler(description.program).compile(description.program);
+            const compiled: CompileOutput = await new CompilerFactory(WABT).pickCompiler(description.program).compile(description.program);
             try {
                 await timeout<Object | void>(`uploading module`, testee.timeout, testee.bed()!.sendRequest(new SourceMap.Mapping(), Message.updateModule(compiled.file))).catch((e) => Promise.reject(e));
                 testee.current = description.program;

--- a/src/manage/Compiler.ts
+++ b/src/manage/Compiler.ts
@@ -98,7 +98,7 @@ export class WatCompiler extends Compiler {
             let out: string = '';
             let err: string = '';
 
-            function handle(error: ExecException | null, stdout: string, stderr: any) {
+            function handle(error: ExecException | null, stdout: string, stderr: string) {
                 out = stdout;
                 err = error?.message ?? '';
             }

--- a/src/manage/Compiler.ts
+++ b/src/manage/Compiler.ts
@@ -124,7 +124,7 @@ export class WatCompiler extends Compiler {
         return new Promise<CompileOutput>((resolve, reject) => {
             const command = `${this.wabt}/wasm-objdump -x -m ${output.file}`;
 
-            const compile = exec(command, (error: ExecException | null, stdout: string, stderr: any) => {
+            const compile = exec(command, (error: ExecException | null, stdout: string) => {
                 output.map = this.parseWasmObjDump(output, stdout.toString());
                 this.emit(CompilationEvents.sourcemap);
                 resolve(output);

--- a/src/manage/Compiler.ts
+++ b/src/manage/Compiler.ts
@@ -18,8 +18,8 @@ enum CompilationEvents {
 
 export interface CompileOutput {
     file: string;
-    out?: String;
-    err?: String;
+    out?: string;
+    err?: string;
     map?: SourceMap.Mapping;
 }
 
@@ -33,13 +33,13 @@ export class CompilerFactory {
     }
 
     public pickCompiler(file: string): Compiler {
-        let fileType = getFileExtension(file);
+        const fileType = getFileExtension(file);
         switch (fileType) {
-            case 'wast' :
-            case 'wat' :
-                return this.wat;
-            case 'ts' :
-                return this.asc;
+        case 'wast' :
+        case 'wat' :
+            return this.wat;
+        case 'ts' :
+            return this.asc;
         }
         throw new Error('Unsupported file type');
     }
@@ -95,15 +95,15 @@ export class WatCompiler extends Compiler {
         return new Promise<CompileOutput>((resolve, reject) => {
             const file = `${dir}/upload.wasm`;
             const command = `${this.wabt}/wat2wasm --no-canonicalize-leb128s --disable-bulk-memory --debug-names -v -o ${file} ${program}`;
-            let out: String = '';
-            let err: String = '';
+            let out: string = '';
+            let err: string = '';
 
-            function handle(error: ExecException | null, stdout: String, stderr: any) {
+            function handle(error: ExecException | null, stdout: string, stderr: any) {
                 out = stdout;
                 err = error?.message ?? '';
             }
 
-            let compile = exec(command, handle);
+            const compile = exec(command, handle);
             this.emit(CompilationEvents.started, command);
 
             compile.on('close', (code) => {
@@ -124,7 +124,7 @@ export class WatCompiler extends Compiler {
         return new Promise<CompileOutput>((resolve, reject) => {
             const command = `${this.wabt}/wasm-objdump -x -m ${output.file}`;
 
-            let compile = exec(command, (error: ExecException | null, stdout: String, stderr: any) => {
+            const compile = exec(command, (error: ExecException | null, stdout: string, stderr: any) => {
                 output.map = this.parseWasmObjDump(output, stdout.toString());
                 this.emit(CompilationEvents.sourcemap);
                 resolve(output);
@@ -212,17 +212,17 @@ export class AsScriptCompiler extends Compiler {
 
         // compile AS to Wasm and WAT
         return new Promise<CompileOutput>(async (resolve, reject) => {
-            let file = `${dir}/upload.wasm`;
+            const file = `${dir}/upload.wasm`;
             const command = await this.getCompilationCommand(program, file);
-            let out: String = '';
-            let err: String = '';
+            let out: string = '';
+            let err: string = '';
 
-            function handle(error: ExecException | null, stdout: String, stderr: any) {
+            function handle(error: ExecException | null, stdout: string, stderr: any) {
                 out = stdout;
                 err = error?.message ?? '';
             }
 
-            let compile = exec(command, handle);
+            const compile = exec(command, handle);
 
             compile.on('close', (code) => {
                 if (code !== 0) {
@@ -239,7 +239,7 @@ export class AsScriptCompiler extends Compiler {
     private getCompilationCommand(program: string, output: string): Promise<string> {
         // builds asc command based on the version of asc
         return new Promise<string>(async (resolve) => {
-            let version: Version = await AsScriptCompiler.retrieveVersion();
+            const version: Version = await AsScriptCompiler.retrieveVersion();
             resolve(`npx asc ${program} --exportTable --disable bulk-memory --sourceMap --debug ` +
                 `${(version.major > 0 || +version.minor >= 20) ? '--outFile' : '--binaryFile'} ${output}`);
         });
@@ -247,15 +247,15 @@ export class AsScriptCompiler extends Compiler {
 
     private static retrieveVersion(): Promise<Version> {
         return new Promise<Version>((resolve, reject) => {
-            let out: String = '';
-            let err: String = '';
+            let out: string = '';
+            let err: string = '';
 
-            function handle(error: ExecException | null, stdout: String, stderr: any) {
+            function handle(error: ExecException | null, stdout: string, stderr: any) {
                 out = stdout;
                 err = error?.message ?? '';
             }
 
-            let compilerVersion = exec('npx asc --version', handle);
+            const compilerVersion = exec('npx asc --version', handle);
             compilerVersion.on('close', (code) => {
                 if (code !== 0) {
                     reject(`asc --version failed: ${err}`);
@@ -299,7 +299,7 @@ function parseLines(context: CompileOutput): SourceMap.SourceLine[] {
 
     const lines: string[] = context.out.split('\n');
     const corrections = extractSectionAddressCorrections(lines);
-    let result: SourceLine[] = [];
+    const result: SourceLine[] = [];
     let lastLineInfo = undefined;
     for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
@@ -331,8 +331,8 @@ function parseLines(context: CompileOutput): SourceMap.SourceLine[] {
 }
 
 export function extractAddressInformation(addressLine: string): string {
-    let regexpr = /^(?<address>([\da-f])+):/;
-    let match = addressLine.match(regexpr);
+    const regexpr = /^(?<address>([\da-f])+):/;
+    const match = addressLine.match(regexpr);
     if (match?.groups) {
         return match.groups.address;
     }

--- a/src/manage/Compiler.ts
+++ b/src/manage/Compiler.ts
@@ -98,7 +98,7 @@ export class WatCompiler extends Compiler {
             let out: string = '';
             let err: string = '';
 
-            function handle(error: ExecException | null, stdout: string, stderr: string) {
+            function handle(error: ExecException | null, stdout: string) {
                 out = stdout;
                 err = error?.message ?? '';
             }
@@ -217,7 +217,7 @@ export class AsScriptCompiler extends Compiler {
             let out: string = '';
             let err: string = '';
 
-            function handle(error: ExecException | null, stdout: string, stderr: any) {
+            function handle(error: ExecException | null, stdout: string) {
                 out = stdout;
                 err = error?.message ?? '';
             }
@@ -250,7 +250,7 @@ export class AsScriptCompiler extends Compiler {
             let out: string = '';
             let err: string = '';
 
-            function handle(error: ExecException | null, stdout: string, stderr: any) {
+            function handle(error: ExecException | null, stdout: string) {
                 out = stdout;
                 err = error?.message ?? '';
             }

--- a/src/manage/Uploader.ts
+++ b/src/manage/Uploader.ts
@@ -35,14 +35,14 @@ export class UploaderFactory {
 
     public pickUploader(specification: TestbedSpecification, args: string[] = []): Uploader {
         switch (specification.type) {
-            case PlatformType.arduino:
-                return new ArduinoUploader(this.arduino, args, specification.options as SerialOptions);
-            case PlatformType.emulator:
-            case PlatformType.emu2emu:
-            case PlatformType.emuproxy:
-                return new EmulatorUploader(this.emulator, args, specification.options as SubprocessOptions);
-            case PlatformType.debug:
-                return new EmulatorConnector(specification.options as SubprocessOptions)
+        case PlatformType.arduino:
+            return new ArduinoUploader(this.arduino, args, specification.options as SerialOptions);
+        case PlatformType.emulator:
+        case PlatformType.emu2emu:
+        case PlatformType.emuproxy:
+            return new EmulatorUploader(this.emulator, args, specification.options as SubprocessOptions);
+        case PlatformType.debug:
+            return new EmulatorConnector(specification.options as SubprocessOptions)
         }
         throw new Error('Unsupported platform type');
     }
@@ -206,7 +206,7 @@ export class ArduinoUploader extends Uploader {
     private stage(program: string): Promise<void> {
         const that = this;
         return new Promise<void>((resolve, reject) => {
-            let compile = exec(`make compile PAUSED=true BINARY=${program}`, {cwd: this.sdkpath});
+            const compile = exec(`make compile PAUSED=true BINARY=${program}`, {cwd: this.sdkpath});
 
             compile.on('close', (code) => {
                 if (code !== 0) {

--- a/src/messaging/Message.ts
+++ b/src/messaging/Message.ts
@@ -128,7 +128,7 @@ export namespace Message {
     }
 
     export async function uploadFile(program: string): Promise<Request<Ack>> {
-        let compiled: CompileOutput = await new CompilerFactory(WABT).pickCompiler(program).compile(program);
+        const compiled: CompileOutput = await new CompilerFactory(WABT).pickCompiler(program).compile(program);
         return updateModule(compiled.file);
     }
 

--- a/src/messaging/Parsers.ts
+++ b/src/messaging/Parsers.ts
@@ -39,7 +39,7 @@ export function ackParser(text: string, ack: string): Ack {
 export function breakpointParser(text: string): Breakpoint {
     const ack: Ack = ackParser(text, 'BP');
 
-    let breakpointInfo = ack.text.match(/BP (0x.*)!/);
+    const breakpointInfo = ack.text.match(/BP (0x.*)!/);
     if (breakpointInfo!.length > 1) {
         return new Breakpoint(parseInt(breakpointInfo![1]), 0); // TODO address to line mapping
     }
@@ -50,7 +50,7 @@ export function breakpointParser(text: string): Breakpoint {
 export function breakpointHitParser(text: string): Breakpoint {
     const ack: Ack = ackParser(text, 'AT ');
 
-    let breakpointInfo = ack.text.match(/AT (0x.*)!/);
+    const breakpointInfo = ack.text.match(/AT (0x.*)!/);
     if (breakpointInfo!.length > 1) {
         return new Breakpoint(parseInt(breakpointInfo![1]), 0); // TODO address to line mapping
     }

--- a/src/reporter/Reporter.ts
+++ b/src/reporter/Reporter.ts
@@ -183,8 +183,8 @@ export class Reporter {
     results(time: number) {
         this.archiver.set('duration (ms)', Math.round(time));
 
-        let passing = this.suites.flatMap((suite) => suite.scenarios).filter((scenario) => scenario.passing()).length;
-        let failing = this.suites.flatMap((suite) => suite.scenarios).filter((scenario) => scenario.failing()).length;
+        const passing = this.suites.flatMap((suite) => suite.scenarios).filter((scenario) => scenario.passing()).length;
+        const failing = this.suites.flatMap((suite) => suite.scenarios).filter((scenario) => scenario.failing()).length;
         const skipped = this.suites.flatMap((suite) => suite.scenarios).filter((scenario) => scenario.skipped()).length;
 
         const scs = this.suites.flatMap((suite) => suite.scenarios);

--- a/src/reporter/Result.ts
+++ b/src/reporter/Result.ts
@@ -20,14 +20,14 @@ export class Result {
 
     toString(): string {
         switch (this.completion) {
-            case Completion.succeeded:
-                return `${bold(inverse(green(' PASS ')))} ${this.name}`;
-            case Completion.uncommenced:
-                return `${bold(inverse(yellow(' SKIP ')))} ${this.name}`;
-            case Completion.error:
-            case Completion.failed:
-            default:
-                return `${bold(inverse(red(' FAIL ')))} ${this.name}\n        ${red(this.completion)}${red(this.description)}`;
+        case Completion.succeeded:
+            return `${bold(inverse(green(' PASS ')))} ${this.name}`;
+        case Completion.uncommenced:
+            return `${bold(inverse(yellow(' SKIP ')))} ${this.name}`;
+        case Completion.error:
+        case Completion.failed:
+        default:
+            return `${bold(inverse(red(' FAIL ')))} ${this.name}\n        ${red(this.completion)}${red(this.description)}`;
 
         }
     }
@@ -74,38 +74,38 @@ export class Result {
 
     public expectBehaviour(actual: any, previous: any, behaviour: Behaviour): void {
         switch (behaviour) {
-            case Behaviour.unchanged:
-                if (deepEqual(actual, previous)) {
-                    this.completion = Completion.succeeded;
-                } else {
-                    this.completion = Completion.failed;
-                    this.description = `Expected ${actual} to equal ${previous}`
-                }
-                break;
-            case Behaviour.changed:
-                if (!deepEqual(actual, previous)) {
-                    this.completion = Completion.succeeded;
-                } else {
-                    this.completion = Completion.failed;
-                    this.description = `Expected ${actual} to be different from ${previous}`
-                }
-                break;
-            case Behaviour.increased:
-                if (actual > previous) {
-                    this.completion = Completion.succeeded;
-                } else {
-                    this.completion = Completion.failed;
-                    this.description = `Expected ${actual} to be greater than ${previous}`
-                }
-                break;
-            case Behaviour.decreased:
-                if (actual < previous) {
-                    this.completion = Completion.succeeded;
-                } else {
-                    this.completion = Completion.failed;
-                    this.description = `Expected ${actual} to be less than ${previous}`
-                }
-                break;
+        case Behaviour.unchanged:
+            if (deepEqual(actual, previous)) {
+                this.completion = Completion.succeeded;
+            } else {
+                this.completion = Completion.failed;
+                this.description = `Expected ${actual} to equal ${previous}`
+            }
+            break;
+        case Behaviour.changed:
+            if (!deepEqual(actual, previous)) {
+                this.completion = Completion.succeeded;
+            } else {
+                this.completion = Completion.failed;
+                this.description = `Expected ${actual} to be different from ${previous}`
+            }
+            break;
+        case Behaviour.increased:
+            if (actual > previous) {
+                this.completion = Completion.succeeded;
+            } else {
+                this.completion = Completion.failed;
+                this.description = `Expected ${actual} to be greater than ${previous}`
+            }
+            break;
+        case Behaviour.decreased:
+            if (actual < previous) {
+                this.completion = Completion.succeeded;
+            } else {
+                this.completion = Completion.failed;
+                this.description = `Expected ${actual} to be less than ${previous}`
+            }
+            break;
         }
     }
 }

--- a/src/reporter/Style.ts
+++ b/src/reporter/Style.ts
@@ -25,10 +25,10 @@ interface Labels {
 // strategy factory
 export function styling(type: StyleType): Style {
     switch (type) {
-        case StyleType.github:
-        case StyleType.plain:
-        default:
-            return new Plain();
+    case StyleType.github:
+    case StyleType.plain:
+    default:
+        return new Plain();
     }
 }
 

--- a/src/sourcemap/SourceMapFactory.ts
+++ b/src/sourcemap/SourceMapFactory.ts
@@ -15,12 +15,12 @@ export class SourceMapFactory {
 
     public async map(source: string, tmpdir?: string): Promise<SourceMap.Mapping> {
         switch (getFileExtension(source)) {
-            case 'wast' :
-            case 'wat' :
-                let compiled: CompileOutput = await this.compilerFactory.pickCompiler(source).compile(source);
-                return new WatMapper(compiled.out ?? '', tmpdir ?? path.dirname(compiled.file), WABT).mapping();
-            case 'ts' :
-                return new AsScriptMapper(source ?? '', tmpdir ?? path.dirname(source)).mapping();
+        case 'wast' :
+        case 'wat' :
+            const compiled: CompileOutput = await this.compilerFactory.pickCompiler(source).compile(source);
+            return new WatMapper(compiled.out ?? '', tmpdir ?? path.dirname(compiled.file), WABT).mapping();
+        case 'ts' :
+            return new AsScriptMapper(source ?? '', tmpdir ?? path.dirname(source)).mapping();
         }
         throw new Error('Unsupported file type');
     }

--- a/src/sourcemap/SourceMapFactory.ts
+++ b/src/sourcemap/SourceMapFactory.ts
@@ -14,10 +14,11 @@ export class SourceMapFactory {
     }
 
     public async map(source: string, tmpdir?: string): Promise<SourceMap.Mapping> {
+        let compiled: CompileOutput;
         switch (getFileExtension(source)) {
         case 'wast' :
         case 'wat' :
-            const compiled: CompileOutput = await this.compilerFactory.pickCompiler(source).compile(source);
+            compiled = await this.compilerFactory.pickCompiler(source).compile(source);
             return new WatMapper(compiled.out ?? '', tmpdir ?? path.dirname(compiled.file), WABT).mapping();
         case 'ts' :
             return new AsScriptMapper(source ?? '', tmpdir ?? path.dirname(source)).mapping();

--- a/src/sourcemap/SourceMapper.ts
+++ b/src/sourcemap/SourceMapper.ts
@@ -107,6 +107,7 @@ export class WatMapper implements SourceMapper {
 
             const locals: Variable[] = [];
             const matches: string[] = input.match(new RegExp(`(func\[${fidx}\][^\n]*)`, 'g')) ?? [];
+            // eslint-disable-next-line
             for (const text in matches) {
                 const index: number = +find(/func\[([0-9]+)/, line.toString());
                 const local: string = find(/<(.*)>/, line.toString());

--- a/src/sourcemap/SourceMapper.ts
+++ b/src/sourcemap/SourceMapper.ts
@@ -153,7 +153,7 @@ function extractDetailedSection(section: string, input: string): string[] {
         return [];
     }
 
-    const count: number = +(lines[i++].split(/[\[\]]+/)[1]);
+    const count: number = +(lines[i++].split(/[[]+/)[1]);
     return lines.slice(i, ((isNaN(count)) ? lines.length : i + count));
 }
 

--- a/src/sourcemap/SourceMapper.ts
+++ b/src/sourcemap/SourceMapper.ts
@@ -170,7 +170,6 @@ function extractMajorSection(section: string, input: string): string[] {
         i++;
     }
 
-    const count: number = +(lines[i++].split(/[[]+/)[1]);
     return lines.slice(start, i);
 }
 

--- a/src/sourcemap/SourceMapper.ts
+++ b/src/sourcemap/SourceMapper.ts
@@ -170,7 +170,7 @@ function extractMajorSection(section: string, input: string): string[] {
         i++;
     }
 
-    const count: number = +(lines[i++].split(/[\[\]]+/)[1]);
+    const count: number = +(lines[i++].split(/[[]+/)[1]);
     return lines.slice(start, i);
 }
 

--- a/src/sourcemap/SourceMapper.ts
+++ b/src/sourcemap/SourceMapper.ts
@@ -20,7 +20,7 @@ export class WatMapper implements SourceMapper {
 
     private lineMapping: SourceMap.SourceLine[];
 
-    constructor(compileOutput: String, tmpdir: string, wabt: string) {
+    constructor(compileOutput: string, tmpdir: string, wabt: string) {
         this.lineMapping = [];
         this.parse(compileOutput);
         this.wabt = wabt;
@@ -34,7 +34,7 @@ export class WatMapper implements SourceMapper {
             let imports: Closure[];
             let sourceMap: Mapping;
 
-            function handleObjDumpStreams(error: ExecException | null, stdout: String, stderr: any) {
+            function handleObjDumpStreams(error: ExecException | null, stdout: string, stderr: any) {
                 if (stderr.match('wasm-objdump')) {
                     reject('Could not find wasm-objdump in the path');
                 } else if (error) {
@@ -62,12 +62,12 @@ export class WatMapper implements SourceMapper {
         });
     }
 
-    private parse(compileOutput: String) {
+    private parse(compileOutput: string) {
         this.lineMapping = [];
         const lines = compileOutput.split('\n');
         for (let i = 0; i < lines.length; i++) {
             if (lines[i].match(/^@ {/)) {
-                let mapping: SourceLine = WatMapper.extractLineInfo(lines[i]);
+                const mapping: SourceLine = WatMapper.extractLineInfo(lines[i]);
                 mapping.instructions = WatMapper.extractAddressInfo(lines[i + 1]);
                 this.lineMapping.push(mapping);
             }
@@ -84,8 +84,8 @@ export class WatMapper implements SourceMapper {
             return [];
         }
 
-        let regexpr = /^(?<address>([\da-f])+):/;
-        let match = line.match(regexpr);
+        const regexpr = /^(?<address>([\da-f])+):/;
+        const match = line.match(regexpr);
         if (match?.groups) {
             return [{address: parseInt(match.groups.address, 16)}];
         }
@@ -93,21 +93,21 @@ export class WatMapper implements SourceMapper {
         throw Error(`Could not parse address from line: ${line}`);
     }
 
-    private static getFunctionInfos(input: String): Closure[] {
-        let functionLines: String[] = extractMajorSection('Function', input);
+    private static getFunctionInfos(input: string): Closure[] {
+        const functionLines: string[] = extractMajorSection('Function', input);
 
         if (functionLines.length === 0) {
             throw Error('Could not messaging \'sourcemap\' section of objdump');
         }
-        let functions: Closure[] = [];
+        const functions: Closure[] = [];
 
-        functionLines.forEach((line: String) => {
+        functionLines.forEach((line: string) => {
             const fidx: number = +find(/func\[([0-9]+)/, line.toString());
             const name: string = find(/<(.*)>/, line.toString());
 
             const locals: Variable[] = [];
             const matches: string[] = input.match(new RegExp(`(func\[${fidx}\][^\n]*)`, 'g')) ?? [];
-            for (let text in matches) {
+            for (const text in matches) {
                 const index: number = +find(/func\[([0-9]+)/, line.toString());
                 const local: string = find(/<(.*)>/, line.toString());
                 locals.push({index: index, name: local, type: 'undefined', mutable: true, value: ''});
@@ -119,18 +119,18 @@ export class WatMapper implements SourceMapper {
         return functions;
     }
 
-    private static getGlobalInfos(input: String): Variable[] {
-        let lines: String[] = extractDetailedSection('Global[', input);
-        let globals: Variable[] = [];
+    private static getGlobalInfos(input: string): Variable[] {
+        const lines: string[] = extractDetailedSection('Global[', input);
+        const globals: Variable[] = [];
         lines.forEach((line) => {
             globals.push(extractGlobalInfo(line));
         });
         return globals;
     }
 
-    private static getImportInfos(input: String): Closure[] {
-        let lines: String[] = extractDetailedSection('Import[', input);
-        let globals: Closure[] = [];
+    private static getImportInfos(input: string): Closure[] {
+        const lines: string[] = extractDetailedSection('Import[', input);
+        const globals: Closure[] = [];
         lines.forEach((line) => {
             globals.push(extractImportInfo(line));
         });
@@ -142,8 +142,8 @@ export class WatMapper implements SourceMapper {
     }
 }
 
-function extractDetailedSection(section: string, input: String): String[] {
-    let lines = input.split('\n');
+function extractDetailedSection(section: string, input: string): string[] {
+    const lines = input.split('\n');
     let i = 0;
     while (i < lines.length && !lines[i].startsWith(section)) {
         i++;
@@ -153,29 +153,29 @@ function extractDetailedSection(section: string, input: String): String[] {
         return [];
     }
 
-    let count: number = +(lines[i++].split(/[\[\]]+/)[1]);
+    const count: number = +(lines[i++].split(/[\[\]]+/)[1]);
     return lines.slice(i, ((isNaN(count)) ? lines.length : i + count));
 }
 
-function extractMajorSection(section: string, input: String): String[] {
-    let lines = input.split('\n');
+function extractMajorSection(section: string, input: string): string[] {
+    const lines = input.split('\n');
     let i = 0;
     while (i < lines.length && !lines[i].startsWith(section)) {
         i++;
     }
 
     i += 2;
-    let start = i;
+    const start = i;
     while (i < lines.length && lines[i] !== '') {
         i++;
     }
 
-    let count: number = +(lines[i++].split(/[\[\]]+/)[1]);
+    const count: number = +(lines[i++].split(/[\[\]]+/)[1]);
     return lines.slice(start, i);
 }
 
-function extractGlobalInfo(line: String): Variable {
-    let global = {} as Variable;
+function extractGlobalInfo(line: string): Variable {
+    const global = {} as Variable;
     let match = line.match(/\[([0-9]+)]/);
     global.index = (match === null) ? NaN : +match[1];
     match = line.match(/ ([if][0-9][0-9]) /);
@@ -189,8 +189,8 @@ function extractGlobalInfo(line: String): Variable {
     return global;
 }
 
-function extractImportInfo(line: String): Closure {
-    let primitive = {} as Closure;
+function extractImportInfo(line: string): Closure {
+    const primitive = {} as Closure;
     let match = line.match(/\[([0-9]+)]/);
     primitive.index = (match === null) ? NaN : +match[1];
     match = line.match(/<([a-zA-Z0-9 ._]+)>/);

--- a/src/sourcemap/SourceMapper.ts
+++ b/src/sourcemap/SourceMapper.ts
@@ -34,7 +34,7 @@ export class WatMapper implements SourceMapper {
             let imports: Closure[];
             let sourceMap: Mapping;
 
-            function handleObjDumpStreams(error: ExecException | null, stdout: string, stderr: any) {
+            function handleObjDumpStreams(error: ExecException | null, stdout: string, stderr: string) {
                 if (stderr.match('wasm-objdump')) {
                     reject('Could not find wasm-objdump in the path');
                 } else if (error) {

--- a/src/testbeds/Platform.ts
+++ b/src/testbeds/Platform.ts
@@ -42,7 +42,7 @@ export abstract class Platform extends EventEmitter implements Testbed {
     // process messages in queue
     protected process(): void {
         // until no complete messages are left
-        for (let message of this.messages) {
+        for (const message of this.messages) {
             const index: number = this.search(message);  // search request
 
             if (0 <= index && index < this.requests.length) {

--- a/src/testbeds/TestbedFactory.ts
+++ b/src/testbeds/TestbedFactory.ts
@@ -21,20 +21,20 @@ export class TestbedFactory {
     }
 
     public async initialize(specification: TestbedSpecification, program: string, args: string[]): Promise<Testbed> {
-        let compiled: CompileOutput = await this.compilerFactory.pickCompiler(program).compile(program).catch((e) => Promise.reject(e));
-        let connection: Connection = await this.uploaderFactory.pickUploader(specification, args).upload(compiled).catch((e) => Promise.reject(e));
+        const compiled: CompileOutput = await this.compilerFactory.pickCompiler(program).compile(program).catch((e) => Promise.reject(e));
+        const connection: Connection = await this.uploaderFactory.pickUploader(specification, args).upload(compiled).catch((e) => Promise.reject(e));
 
         switch (specification.type) {
-            case PlatformType.arduino:
-                return new Arduino(connection as Serial);
-            case PlatformType.emulator:
-            case PlatformType.emu2emu:
-            case PlatformType.debug:
-                return new Emulator(connection as SubProcess);
-            case PlatformType.emuproxy:
-                return new DummyProxy(connection as SubProcess, specification as ProxySpecification);
-            default:
-                return Promise.reject('Platform not implemented.');
+        case PlatformType.arduino:
+            return new Arduino(connection as Serial);
+        case PlatformType.emulator:
+        case PlatformType.emu2emu:
+        case PlatformType.debug:
+            return new Emulator(connection as SubProcess);
+        case PlatformType.emuproxy:
+            return new DummyProxy(connection as SubProcess, specification as ProxySpecification);
+        default:
+            return Promise.reject('Platform not implemented.');
         }
     }
 }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,5 +1,5 @@
 export function getFileExtension(file: string): string {
-    let result = /(?:\.([^.]+))?$/.exec(file)
+    const result = /(?:\.([^.]+))?$/.exec(file)
     if (result === null || result.length < 1) {
         throw Error('Could not determine file type');
     }


### PR DESCRIPTION
- Enforce consistent indentation
- Require `const` declarations for variables that are never reassigned after declared
- Prefer using the primitive string as a type name, rather than the upper-cased String
- Disallow unnecessary escape characters
- Disallow unused variables