### PR TITLE
Fix incorrect comparison due to enum collision

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "latch",
   "description": "A testing language for constraint environments",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "type": "commonjs",
   "exports": {
     "types": "./dist/types/index.d.ts",

--- a/src/messaging/Parsers.ts
+++ b/src/messaging/Parsers.ts
@@ -19,7 +19,7 @@ export function invokeParser(text: string): WASM.Value<Type> | Exception {
     if (exception(text)) {
         return {text: text};
     }
-    const stack: {value: any, type: any}[] = stateParser(text).stack!;
+    const stack: WASM.Value<Type>[] = stateParser(text).stack!;
     if (stack.length == 0) {
         return nothing;
     }
@@ -60,7 +60,7 @@ export function breakpointHitParser(text: string): Breakpoint {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function stacking(objects: {value: any, type: any}[]): WASM.Value<Type>[] {
+function stacking(objects: { value: any, type: any }[]): WASM.Value<Type>[] {
     const stacked: WASM.Value<Type>[] = [];
     for (const object of objects) {
         let value: number = object.value;

--- a/src/sourcemap/Wasm.ts
+++ b/src/sourcemap/Wasm.ts
@@ -3,18 +3,18 @@ import * as leb from "@thi.ng/leb128";
 export namespace WASM {
 
     export enum Float {
-        f32,
-        f64,
+        f32 = 0,
+        f64 = 1,
     }
 
     export enum Integer {
-        i32,
-        i64,
+        i32 = 2,
+        i64 = 3,
     }
 
     export enum Special {
-        nothing,
-        unknown
+        nothing = 4,
+        unknown = 5
     }
 
     export type Type = Float | Integer | Special;


### PR DESCRIPTION
Refactor of `WASM.Type` lead to enum collisions where for instance `Float.f32` values were seen as `Special.nothing` during comparison. In turn leading to false positives.